### PR TITLE
Fix PAPI bug error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/releases/</url>
         </repository>
     </repositories>
 
@@ -95,7 +95,7 @@
     <dependencies>
         <dependency>
             <groupId>me.clip</groupId>
-            <artifactId>PlaceholderAPI</artifactId>
+            <artifactId>placeholderapi</artifactId>
             <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/xuan/cat/fartherviewdistance/code/ChunkIndex.java
+++ b/src/main/java/xuan/cat/fartherviewdistance/code/ChunkIndex.java
@@ -64,8 +64,14 @@ public final class ChunkIndex extends JavaPlugin {
                         new ChunkEvent(ChunkIndex.chunkServer, ChunkIndex.branchPacket, ChunkIndex.branchMinecraft),
                         (Plugin) this);
         // protocolManager.addPacketListener(new ChunkPacketEvent(plugin, chunkServer));
-        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
-            ChunkPlaceholder.registerPlaceholder();
+        try {
+            if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+                Class.forName("me.clip.placeholderapi.expansion.PlaceholderExpansion");
+                ChunkPlaceholder.registerPlaceholder();
+                this.getLogger().info("PlaceholderAPI detected. Placeholders working!");
+            }
+        } catch (NoClassDefFoundError | ClassNotFoundException e) {
+            this.getLogger().warning("PlaceholderAPI not found. Placeholders will not be available!");
         }
 
         // Cria a árvore do comando "viewdistance" com os subcomandos e argumentos
@@ -118,7 +124,9 @@ public final class ChunkIndex extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // ChunkPlaceholder.unregisterPlaceholder();
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            ChunkPlaceholder.unregisterPlaceholder();
+        }
         if (ChunkIndex.chunkServer != null)
             ChunkIndex.chunkServer.close();
     }


### PR DESCRIPTION
Fixed bug with PAPI not found. [#21]
Now working! Tested in 1.21.5 (build 40).

PAPI dependency updated in pom.xml and added exception controls to manage papi in code.

![imagen](https://github.com/user-attachments/assets/09e9d23c-5699-4d9d-b829-e31c6cf4629b)

