### PR TITLE
Added folia support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=10.4.0
+version=10.5.0
 java=25
 netty_version=4.2.15.Final
 paper_version=26.1.2.build.72-stable

--- a/src/main/java/xuan/cat/fartherviewdistance/code/ChunkIndex.java
+++ b/src/main/java/xuan/cat/fartherviewdistance/code/ChunkIndex.java
@@ -32,6 +32,7 @@ public final class ChunkIndex extends JavaPlugin {
     private static BranchPacket branchPacket;
     private static BranchMinecraft branchMinecraft;
     private static final Set<String> SUPPORTED = Set.of("26.1", "26.1.1", "26.1.2", "26.2");
+    private static boolean folia;
 
     @Override
     public void onEnable() {
@@ -45,10 +46,20 @@ public final class ChunkIndex extends JavaPlugin {
         final String minecraftVersion = Bukkit.getMinecraftVersion();
 
         if (ChunkIndex.SUPPORTED.contains(minecraftVersion)) {
+            // https://docs.papermc.io/paper/dev/folia-support/#checking-for-folia
+            try {
+                Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+                ChunkIndex.folia = true;
+            }
+            catch (ClassNotFoundException _) {
+                ChunkIndex.folia = false;
+            }
+
             ChunkIndex.branchPacket = new PacketCode();
             ChunkIndex.branchMinecraft = new MinecraftCode();
             ChunkIndex.chunkServer = new ChunkServer(ChunkIndex.configData, this, ViewShape.ROUND,
-                    ChunkIndex.branchMinecraft, ChunkIndex.branchPacket);
+                    ChunkIndex.branchMinecraft, ChunkIndex.branchPacket, ChunkIndex.folia);
+
         } else {
             this.getLogger().warning(
                     "Unsupported Version, for versions < 1.21.4 downgrade to 9.9.2, for versions > 1.21.4 download the corresponding version");
@@ -125,7 +136,7 @@ public final class ChunkIndex extends JavaPlugin {
         });
         // bStats
         final int pluginId = 26238;
-        final Metrics metrics = new Metrics(this, pluginId);
+        final Metrics metrics = new Metrics(this, pluginId, folia);
         try {
             // Access the private 'metricsBase' field on Metrics
             final java.lang.reflect.Field baseField = metrics.getClass().getDeclaredField("metricsBase");

--- a/src/main/java/xuan/cat/fartherviewdistance/code/ChunkServer.java
+++ b/src/main/java/xuan/cat/fartherviewdistance/code/ChunkServer.java
@@ -18,6 +18,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -57,7 +59,10 @@ public final class ChunkServer {
     private boolean running = true;
     public final BranchMinecraft branchMinecraft;
     public final BranchPacket branchPacket;
+    public final boolean folia;
+
     private final Set<BukkitTask> bukkitTasks = ConcurrentHashMap.newKeySet();
+    private final Set<ScheduledTask> foliaTasks = ConcurrentHashMap.newKeySet();
 
     public static final Random random = new Random(); // SyncKey
     private ScheduledExecutorService multithreadedService;
@@ -88,25 +93,37 @@ public final class ChunkServer {
      * Sets up scheduled tasks for synchronous and asynchronous operations.
      */
     public ChunkServer(final ConfigData configData, final Plugin plugin, final ViewShape viewShape,
-            final BranchMinecraft branchMinecraft,
-            final BranchPacket branchPacket) {
+                       final BranchMinecraft branchMinecraft,
+                       final BranchPacket branchPacket,
+                       final boolean folia) {
         this.configData = configData;
         this.plugin = plugin;
         this.branchMinecraft = branchMinecraft;
         this.branchPacket = branchPacket;
+        this.folia = folia;
         this.viewShape = viewShape;
 
-        final BukkitScheduler scheduler = Bukkit.getScheduler();
-        this.bukkitTasks.add(scheduler.runTaskTimer(plugin, this::tickSync, 0, 1));
-        this.bukkitTasks.add(scheduler.runTaskTimerAsynchronously(plugin, this::tickAsync, 0, 1));
-        this.bukkitTasks.add(scheduler.runTaskTimerAsynchronously(plugin, this::tickReport, 0, 20));
+        if(folia) {
+            this.foliaTasks.add(Bukkit.getGlobalRegionScheduler().runAtFixedRate(plugin, _ -> tickSync(), 1, 1));
+
+            final AsyncScheduler asyncScheduler = Bukkit.getAsyncScheduler();
+            this.foliaTasks.add(asyncScheduler.runAtFixedRate(plugin, _ -> tickAsync(), 50, 50, TimeUnit.MILLISECONDS)); // one tick
+            this.foliaTasks.add(asyncScheduler.runAtFixedRate(plugin, _ -> tickReport(), 1, 1, TimeUnit.SECONDS)); // twenty ticks
+        }
+        else {
+            final BukkitScheduler scheduler = Bukkit.getScheduler();
+            this.bukkitTasks.add(scheduler.runTaskTimer(plugin, this::tickSync, 0, 1));
+            this.bukkitTasks.add(scheduler.runTaskTimerAsynchronously(plugin, this::tickAsync, 0, 1));
+            this.bukkitTasks.add(scheduler.runTaskTimerAsynchronously(plugin, this::tickReport, 0, 20));
+        }
+
         this.reloadMultithreaded();
     }
 
     /**
      * Initializes a PlayerChunkView for a given player and stores it in the
      * playersViewMap.
-     * 
+     *
      * @param player The player for whom the view is being initialized.
      * @return The initialized PlayerChunkView.
      */
@@ -213,7 +230,8 @@ public final class ChunkServer {
         this.waitMoveSyncQueue.removeIf(runnable -> {
             try {
                 runnable.run();
-            } catch (final Exception exception) {
+            }
+            catch (final Exception exception) {
                 exception.printStackTrace();
             }
             return true;
@@ -236,6 +254,20 @@ public final class ChunkServer {
         this.worldsGeneratedChunk.values().forEach(generatedChunk -> generatedChunk.set(0));
     }
 
+    private void fetchNbt(final CompletableFuture<BranchNBT> future, final World world, final Chunk chunk, final BranchChunkLight chunkLight) {
+        try {
+            final List<Runnable> asyncRunnable = new ArrayList<>();
+            final BranchNBT chunkNBT = this.branchMinecraft.fromChunk(world, chunk).toNBT(chunkLight, asyncRunnable);
+            // These runnables capture live chunk section data and must also run on the
+            // server thread.
+            asyncRunnable.forEach(Runnable::run);
+            future.complete(chunkNBT);
+        }
+        catch (final Throwable throwable) {
+            future.completeExceptionally(throwable);
+        }
+    }
+
     /**
      * Serializes a live chunk on the server thread to avoid async access to mutable
      * NMS chunk internals.
@@ -244,17 +276,14 @@ public final class ChunkServer {
             throws InterruptedException, ExecutionException {
         final CompletableFuture<BranchNBT> syncNBT = new CompletableFuture<>();
         this.waitMoveSyncQueue.add(() -> {
-            try {
-                final List<Runnable> asyncRunnable = new ArrayList<>();
-                final BranchNBT chunkNBT = this.branchMinecraft.fromChunk(world, chunk).toNBT(chunkLight,
-                        asyncRunnable);
-                // These runnables capture live chunk section data and must also run on the
-                // server thread.
-                asyncRunnable.forEach(Runnable::run);
-                syncNBT.complete(chunkNBT);
-            } catch (final Throwable throwable) {
-                syncNBT.completeExceptionally(throwable);
+            if(folia) {
+                Bukkit.getRegionScheduler().run(plugin, new Location(world, (chunk.getX() << 4) + 8, 0, (chunk.getZ() << 4) + 8), _ -> fetchNbt(
+                        syncNBT, world, chunk, chunkLight
+                ));
+                return;
             }
+
+            fetchNbt(syncNBT, world, chunk, chunkLight);
         });
         return syncNBT.get();
     }
@@ -694,6 +723,8 @@ public final class ChunkServer {
     void close() {
         this.running = false;
         for (final BukkitTask task : this.bukkitTasks)
+            task.cancel();
+        for (final ScheduledTask task : foliaTasks)
             task.cancel();
         this.multithreadedService.shutdown();
     }

--- a/src/main/java/xuan/cat/fartherviewdistance/code/Metrics.java
+++ b/src/main/java/xuan/cat/fartherviewdistance/code/Metrics.java
@@ -62,7 +62,7 @@ public class Metrics {
      *                  href="https://bstats.org/what-is-my-plugin-id">What is my
      *                  plugin id?</a>
      */
-    public Metrics(Plugin plugin, int serviceId) {
+    public Metrics(Plugin plugin, int serviceId, boolean folia) {
         this.plugin = plugin;
         // Get the config file
         File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
@@ -95,11 +95,6 @@ public class Metrics {
         boolean logErrors = config.getBoolean("logFailedRequests", false);
         boolean logSentData = config.getBoolean("logSentData", false);
         boolean logResponseStatusText = config.getBoolean("logResponseStatusText", false);
-        boolean isFolia = false;
-        try {
-            isFolia = Class.forName("io.papermc.paper.threadedregions.RegionizedServer") != null;
-        } catch (Exception e) {
-        }
         metricsBase = new // See https://github.com/Bastian/bstats-metrics/pull/126
         // See https://github.com/Bastian/bstats-metrics/pull/126
         // See https://github.com/Bastian/bstats-metrics/pull/126
@@ -114,7 +109,7 @@ public class Metrics {
                 enabled,
                 this::appendPlatformData,
                 this::appendServiceData,
-                isFolia
+                folia
                         ? null
                         : submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
                 plugin::isEnabled,

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -3,6 +3,7 @@ version: $version
 main: xuan.cat.fartherviewdistance.code.ChunkIndex
 api-version: "26.1"
 authors: [xuancat0208, EuSouVoce, Lumine1909, Mapacheee, just_lofe, HauserGrim]
+folia-supported: true
 dependencies:
   server:
     PlaceholderAPI:


### PR DESCRIPTION
Added support for the PaperMC's [Folia](https://github.com/PaperMC/Folia). Tested it on the latest Minecraft version: 26.2 (although an official Folia build for 26.2 hasn't been published yet). On the screenshot, i joined from two accounts and flew far away from each other so players are in two, different regions.

<img width="1920" height="1080" alt="Screenshot_20260708_230640" src="https://github.com/user-attachments/assets/5d39c014-f129-4cf3-8636-69847a6a513b" />
